### PR TITLE
Added rustfmt file for workspace

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 80
+use_small_heuristics = "Max"


### PR DESCRIPTION
Rustfmt (https://rust-lang.github.io/rustfmt/) can help keep some formatting consistency across contributors. There are a bunch of settings that can be added, though many are unstable (only work nightly I believe).

If using clion, you can tell the IDE to use these settings by going to Preferences -> Language & Frameworks -> Rust -> Rustfmt, and checking the 2 checkboxes.