### PR TITLE
Run clippy on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,13 @@ release: ## Build and install (release) 🎉
 .PHONY: aurae
 aurae: ## Initialize and compile aurae
 	@if [ ! -d aurae ]; then printf "\n\nError: Missing submodules. Run 'make submodule' to download aurae source before compiling.\n\n"; exit 1; fi
+	@$(cargo) clippy -p aurae
 	@$(cargo) install --path ./aurae --debug
 
 .PHONY: auraed
 auraed: ## Initialize and compile auraed
 	@if [ ! -d auraed ]; then printf "\n\nError:\nun 'make submodule' to download auraed source before compiling.\n\n"; exit 1; fi
+	@$(cargo) clippy -p auraed
 	@$(cargo) install --path ./auraed --debug
 
 test: ## Run the tests

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true


### PR DESCRIPTION
Clippy has a default configuration, so it will output warnings for more than explicitly configured. This should be overridable, but starting with the defaults seems like a good choice.