### PR TITLE
During make steps, prevent git from using a pager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ auraed: ## Initialize and compile auraed
 test: ## Run the tests
 	@$(cargo) test
 
+export GIT_PAGER = cat
+
 push: ## (git) Push branch="NAME"
 	cd aurae && git push origin $(branch)
 	cd auraed && git push origin $(branch)


### PR DESCRIPTION
During the push/submodules/add `make` steps, git can interrupt the script by auto-opening the pager for things like the branch list. To prevent this, this PR sets the git pager to `cat` so it doesn't require interactivity.