### PR TITLE
Fix default PKI config path and submodule branches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,9 +5,12 @@
 [submodule "authx"]
 	path = authx
 	url = git@github.com:aurae-runtime/authx.git
+	branch = main
 [submodule "auraectl"]
 	path = auraectl
 	url = git@github.com:wesen/auraectl
+	branch = main
 [submodule "auraescript"]
 	path = auraescript
 	url = git@github.com:aurae-runtime/auraescript.git
+	branch = main

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ submodule: ## Initialize all submodules
 .PHONY: config
 config: ## Set up default config
 	@mkdir -p $(HOME)/.aurae
-	@cp -v aurae/default.config.toml $(HOME)/.aurae/config
+	@cp -v auraescript/default.config.toml $(HOME)/.aurae/config
 	@sed -i 's|~|$(HOME)|g' $(HOME)/.aurae/config
 	@mkdir -p $(HOME)/.aurae/pki
 	@cp -v pki/* $(HOME)/.aurae/pki


### PR DESCRIPTION
Running `make pki config` as per the README fails as it points to `aurae/default.config.tml`, when the file lives at `auraescript/default.config.toml`.

Additionally, running `make submodules` on my machine failed for `api` and `auraescript` as they didn't specify the `main` branch, updated `.gitmodules` to address this.