### PR TITLE
removed clippy.toml due to bad config value

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,0 @@
-allow-unwrap-in-tests = true


### PR DESCRIPTION
I ran clippy (`cargo clippy --all-features --all -- -D clippy::all -D warnings`) and ran into the error below

```
error: error reading Clippy's configuration file `/var/home/mooch/sra/aurae/clippy.toml`: unknown field `allow-unwrap-in-tests`, expected one of `avoid-breaking-exported-api`, `msrv`, `blacklisted-names`, `cognitive-complexity-threshold`, `cyclomatic-complexity-threshold`, `doc-valid-idents`, `too-many-arguments-threshold`, `type-complexity-threshold`, `single-char-binding-names-threshold`, `too-large-for-stack`, `enum-variant-name-threshold`, `enum-variant-size-threshold`, `verbose-bit-mask-threshold`, `literal-representation-threshold`, `trivial-copy-size-limit`, `pass-by-value-size-limit`, `too-many-lines-threshold`, `array-size-threshold`, `vec-box-size-threshold`, `max-trait-bounds`, `max-struct-bools`, `max-fn-params-bools`, `warn-on-all-wildcard-imports`, `disallowed-methods`, `disallowed-types`, `unreadable-literal-lint-fractions`, `upper-case-acronyms-aggressive`, `cargo-ignore-publish`, `standard-macro-braces`, `enforced-import-renames`, `allowed-scripts`, `enable-raw-pointer-heuristic-for-send`, `max-suggested-slice-pattern-length`, `await-holding-invalid-types`, `max-include-file-size`, `third-party` at line 1 column 1
```
Removing `clippy.toml`, which only contained `allow-unwrap-in-tests`